### PR TITLE
fix: MCTUNE-1209

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "5.5.3",
   "main": "./index.js",
   "dependencies": {
-    "mssql": "3.3.0",
+    "mssql": "git://github.com/patriksimek/node-mssql",
     "ut-error": "^5.3.10",
     "when": "3.7.7",
     "xml2js": "0.4.17"


### PR DESCRIPTION
There is issue with utf8 characters in XML format in mssql module which I fixed and the fix is merged, but not published in npm.
I contacted the author and he is not publishing latest changes in version 3.x, because there are breaking changes and he is planning to introduce them in version 4.0 which have no ETA.
For now we can use the module from github