### PR TITLE
WIP: skip schema update

### DIFF
--- a/index.js
+++ b/index.js
@@ -532,6 +532,9 @@ SqlPort.prototype.updateSchema = function(schema) {
                         }
                     });
 
+                    if (self.config.updateSchema === false) {
+                        queries = [];
+                    }
                     var request = self.getRequest();
                     var updated = [];
                     return when.reduce(queries, function(result, query) {
@@ -970,6 +973,9 @@ SqlPort.prototype.loadSchema = function(objectList) {
     var request = this.getRequest();
     request.multiple = true;
 
+    if (self.config.updateSchema === false && fs.existsSync('db/schema' + (objectList ? 1 : 0) + '.txt')) {
+        return JSON.parse(require('fs').readFileSync('db/schema' + (objectList ? 1 : 0) + '.txt', {encoding: 'utf8'}));
+    }
     return request.query(mssqlQueries.loadSchema()).then(function(result) {
         var schema = {source: {}, parseList: [], types: {}, deps: {}};
         result[0].reduce(function(prev, cur) { // extract source code of procedures, views, functions, triggers
@@ -1023,6 +1029,9 @@ SqlPort.prototype.loadSchema = function(objectList) {
         Object.keys(schema.types).forEach(function(type) { // extract pseudo source code of user defined table types
             schema.source[type] = schema.types[type].map(fieldSource).join('\r\n');
         });
+        if(self.config.updateSchema !== undefined) {
+            require('fs').writeFileSync('db/schema' + (objectList ? 1 : 0) + '.txt', JSON.stringify(schema));
+        }
         return schema;
     });
 };

--- a/index.js
+++ b/index.js
@@ -1029,7 +1029,7 @@ SqlPort.prototype.loadSchema = function(objectList) {
         Object.keys(schema.types).forEach(function(type) { // extract pseudo source code of user defined table types
             schema.source[type] = schema.types[type].map(fieldSource).join('\r\n');
         });
-        if(self.config.updateSchema !== undefined) {
+        if (self.config.updateSchema !== undefined) {
             require('fs').writeFileSync('db/schema' + (objectList ? 1 : 0) + '.txt', JSON.stringify(schema));
         }
         return schema;


### PR DESCRIPTION
This feature helps starting server faster and it's implemented for dev purposes.
It allows the usage fo the following configuration: db.schemaUpdate: TRUE|FALSE.
When this configuration is missing, port starts as usual. The first time when
the feature is used or first time after any db schema update, it needs to be
set to TRUE and it creates 2 txt files in db/ directory which will be later read
for all subsequent runs with setting set to FALSE.