### PR TITLE
refactor: $meta.saveAs

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -21,6 +21,8 @@ module.exports = create => {
         singleResultsetExpected: create('singleResultsetExpected', PortSQL, 'Single resultset expected'),
         oneRowExpected: create('oneRowExpected', PortSQL, 'Exactly one row was expected in the result'),
         maxOneRowExpected: create('maxOneRowExpected', PortSQL, 'Maximum one row was expected in the result'),
-        minOneRowExpected: create('minOneRowExpected', PortSQL, 'Minimum one row was expected in the result')
+        minOneRowExpected: create('minOneRowExpected', PortSQL, 'Minimum one row was expected in the result'),
+        absolutePath: create('absolutePath', PortSQL, 'Absolute path error'),
+        invalidFileLocation: create('invalidFileLocation', PortSQL, 'Writing outside of base directory is forbidden')
     };
 };

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "7.1.1",
   "main": "./index.js",
   "dependencies": {
+    "fs-plus": "3.0.2",
     "lodash.merge": "4.6.0",
     "through2": "2.0.3",
     "ut-mssql": "3.4.3",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "ut-tools": "^5.32.5",
     "pegjs": "0.10.0"
   },
+  "peerDependency": {
+    "tedious": "^2.0.0"
+  },
   "scripts": {
     "lint": "ut-lint .",
     "release": "ut-release",

--- a/saveAs/csv.js
+++ b/saveAs/csv.js
@@ -1,21 +1,21 @@
+const EOL = require('os').EOL;
 var Transform = require('./transform');
 let { getResultSetName } = require('./helpers');
 class CsvTransform extends Transform {
     constructor(stream, config) {
         super(stream, config);
         this.options = {
-            canPushRow: !config.namedSet,
-            newLine: '\n'
+            canPushRow: !config.namedSet
         };
     }
     onStart() {
         let { columns } = this.config;
-        this.stream.push((columns || []).map((col) => `"${col.displayName}"`).join(this.config.seperator || ',') + this.options.newLine);
+        this.stream.push((columns || []).map((col) => `"${col.displayName}"`).join(this.config.seperator || ',') + EOL);
     }
     onRow(chunk) {
         this.options.canPushRow && this.stream.push((this.config.columns || []).map((col) => {
             return ['"', col.transform ? col.transform(chunk[col.name], chunk) : chunk[col.name], '"'].join('');
-        }).join(this.config.seperator || ',') + this.options.newLine);
+        }).join(this.config.seperator || ',') + EOL);
     }
     onResultSet(chunk) {
         let { resultSetName, namedSet } = this.config;

--- a/saveAs/csv.js
+++ b/saveAs/csv.js
@@ -1,0 +1,26 @@
+var Transform = require('./transform');
+let { getResultSetName } = require('./helpers');
+class CsvTransform extends Transform {
+    constructor(stream, config) {
+        super(stream, config);
+        this.options = {
+            canPushRow: !config.namedSet,
+            newLine: '\n'
+        };
+    }
+    onStart() {
+        let { columns } = this.config;
+        this.stream.push((columns || []).map((col) => `"${col.displayName}"`).join(this.config.seperator || ',') + this.options.newLine);
+    }
+    onRow(chunk) {
+        this.options.canPushRow && this.stream.push((this.config.columns || []).map((col) => {
+            return ['"', col.transform ? col.transform(chunk[col.name], chunk) : chunk[col.name], '"'].join('');
+        }).join(this.config.seperator || ',') + this.options.newLine);
+    }
+    onResultSet(chunk) {
+        let { resultSetName, namedSet } = this.config;
+        var cResultSetName = getResultSetName(chunk);
+        this.options.canPushRow = ((namedSet && resultSetName && cResultSetName === resultSetName) || !namedSet);
+    }
+}
+module.exports = CsvTransform;

--- a/saveAs/helpers.js
+++ b/saveAs/helpers.js
@@ -1,0 +1,7 @@
+function getResultSetName(chunk) {
+    let keys = Object.keys(chunk);
+    return keys.length > 0 && keys[0].toLowerCase() === 'resultsetname' ? chunk[keys[0]] : null;
+}
+module.exports = {
+    getResultSetName
+};

--- a/saveAs/index.js
+++ b/saveAs/index.js
@@ -1,0 +1,40 @@
+const through2 = require('through2');
+let { getResultSetName } = require('./helpers');
+var transforms = {
+    json: require('./json')
+};
+module.exports = function(request, saveAs) {
+    var config = Object.assign({}, {
+        namedSet: undefined,
+        single: undefined
+    }, typeof saveAs === 'object' ? saveAs : {});
+    var filename = typeof saveAs === 'string' ? saveAs : saveAs.filename;
+    var ext = filename.split('.').pop();
+    let Transform = transforms[ext];
+    if (!Transform) throw new Error('File type not supported');
+    var transform;
+    let counter = 1;
+    request.on('recordset', function(cols) {
+        counter++;
+    });
+
+    return request.pipe(through2({objectMode: true}, function(chunk, encoding, next) {
+        if (config.namedSet === undefined) { // called only once to write object start literal
+            config.namedSet = !!getResultSetName(chunk);
+            transform = new Transform(this, config);
+            transform.onStart();
+        }
+        if (!config.namedSet || counter % 2) { // handle rows
+            transform.onRow(chunk);
+        } else { // handle resultsets
+            if (getResultSetName(chunk)) {
+                transform.setOptions('single', !!chunk.single);
+                transform.onResultSet(chunk);
+            }
+        }
+        next();
+    }, function(next) {
+        transform.onEnd();
+        next();
+    }));
+};

--- a/saveAs/index.js
+++ b/saveAs/index.js
@@ -1,7 +1,8 @@
 const through2 = require('through2');
 let { getResultSetName } = require('./helpers');
 var transforms = {
-    json: require('./json')
+    json: require('./json'),
+    csv: require('./csv')
 };
 module.exports = function(request, saveAs) {
     var config = Object.assign({}, {

--- a/saveAs/json.js
+++ b/saveAs/json.js
@@ -40,7 +40,7 @@ class JsonTransform extends Transform {
         }
         this.stream.push(`"${current}": ${!single ? '[' : ''}`);
         this.options.comma = '';
-        this.options.resultsetPrev =  chunk;
+        this.options.resultsetPrev = chunk;
     }
 }
 module.exports = JsonTransform;

--- a/saveAs/json.js
+++ b/saveAs/json.js
@@ -1,0 +1,46 @@
+var Transform = require('./transform');
+let { getResultSetName } = require('./helpers');
+class JsonTransform extends Transform {
+    constructor(stream, config) {
+        super(stream, config);
+        this.options = {
+            comma: '',
+            resultsetPrev: null
+        };
+    }
+    onStart() {
+        this.stream.push(this.config.namedSet ? '{' : '[');
+    }
+    onEnd() {
+        let { namedSet, single } = this.config;
+        if (namedSet !== undefined) {
+            if (single === false) {
+                this.stream.push(']'); // push end of array literal If the last object is not a single
+            }
+            this.stream.push(namedSet ? '}' : ']'); //  write object end literal
+        }
+    }
+    onRow(chunk) {
+        let { comma } = this.options;
+        this.stream.push(comma + JSON.stringify(chunk));
+        if (comma === '') {
+            this.options.comma = ',';
+        }
+    }
+    onResultSet(chunk) {
+        var current = getResultSetName(chunk);
+        let { single } = this.config;
+        let { comma, resultsetPrev } = this.options;
+        if (resultsetPrev) {
+            if (comma === '') {
+                this.stream.push(resultsetPrev.single ? '{},' : '],'); // handling empty result set
+            } else {
+                this.stream.push(resultsetPrev.single ? ',' : '],'); // handling end
+            }
+        }
+        this.stream.push(`"${current}": ${!single ? '[' : ''}`);
+        this.options.comma = '';
+        this.options.resultsetPrev =  chunk;
+    }
+}
+module.exports = JsonTransform;

--- a/saveAs/transform.js
+++ b/saveAs/transform.js
@@ -1,0 +1,15 @@
+class Transform {
+    constructor(stream, config) {
+        this.stream = stream;
+        this.config = config || {};
+    }
+    setOptions(key, value) {
+        this.config[key] = value;
+    }
+    onStart() {};
+    onRow(chunk) {}
+    onResultSet(chunk) {}
+    onEnd() {}
+}
+
+module.exports = Transform;


### PR DESCRIPTION
Here,

1. the code which is used to save the resultset into a file by using stream option, is separated.
2. add csv output file, the csv $meta.saveAs is shown below
```
   $meta.saveAs = {
           filename: 'customers.csv',
           resultSetName: 'customers',
           columns: [{
                name: 'firstName',
                displayName: 'First Name',
                transform: (value, rowData) => { return value; }
           }]
    }
```
Now it support json and csv type output file and for other type of export, please extend this functionality by inheriting the Transform (saveAs/transform/index.js) class .
