### PR TITLE
fix: saveAs

### DIFF
--- a/saveAs/csv.js
+++ b/saveAs/csv.js
@@ -1,6 +1,9 @@
 const EOL = require('os').EOL;
 var Transform = require('./transform');
 let { getResultSetName } = require('./helpers');
+const formatCellValue = (value) => {
+    return value && `${value.replace(/\n|,/g, ' ')}`;
+};
 class CsvTransform extends Transform {
     constructor(stream, config) {
         super(stream, config);
@@ -10,11 +13,11 @@ class CsvTransform extends Transform {
     }
     onStart() {
         let { columns } = this.config;
-        this.stream.push((columns || []).map((col) => `"${col.displayName}"`).join(this.config.seperator || ',') + EOL);
+        this.stream.push((columns || []).map((col) => formatCellValue(col.displayName)).join(this.config.seperator || ',') + EOL);
     }
     onRow(chunk) {
         this.options.canPushRow && this.stream.push((this.config.columns || []).map((col) => {
-            return ['"', col.transform ? col.transform(chunk[col.name], chunk) : chunk[col.name], '"'].join('');
+            return formatCellValue(col.transform ? col.transform(chunk[col.name], chunk) : chunk[col.name]);
         }).join(this.config.seperator || ',') + EOL);
     }
     onResultSet(chunk) {


### PR DESCRIPTION
Here I have removed , record set event handler which is used to decide the chunk type (resultset or row) based on counter value. Because, request.on('eventname', () => {}) and request.pipe(Transform) both are not in same frequency. it seems the counter increment is not reliable

ex. resultset, { a: [1000 records], b : [1 record], c: [3]}]

here the counter may go at **level c** , where the transform stream may still process the 1 st one **level a**. it seems wrong result set. I faced such a issue in audit log fetch action.

Please correct me, If I am wrong.