### PR TITLE
fix: check if stored procedure is linked before calling it

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -24,6 +24,7 @@ module.exports = ({defineError, getError, fetchErrors}) => {
         defineError('minOneRowExpected', PortSQL, 'Minimum one row was expected in the result');
         defineError('absolutePath', PortSQL, 'Absolute path error');
         defineError('invalidFileLocation', PortSQL, 'Writing outside of base directory is forbidden');
+        defineError('spNotFound', PortSQL, 'Stored Procedure not found: {name}');
     }
 
     return fetchErrors('portSQL');

--- a/index.js
+++ b/index.js
@@ -489,16 +489,23 @@ module.exports = function({utPort}) {
                     fileName,
                     objectName,
                     objectId,
-                    callSP: () => this.methods[objectName].call(
-                        this,
-                        typeof params === 'function' ? params(config) : params,
-                        {
-                            auth: {
-                                actorId: 0
-                            },
-                            method: objectName,
-                            userName: 'SYSTEM'
-                        })
+                    callSP: () => {
+                        if (typeof this.methods[objectName] !== 'function') {
+                            throw sqlPortErrors['portSQL.spNotFound']({params: {name: objectName}});
+                        }
+
+                        return this.methods[objectName].call(
+                            this,
+                            typeof params === 'function' ? params(config) : params,
+                            {
+                                auth: {
+                                    actorId: 0
+                                },
+                                method: objectName,
+                                userName: 'SYSTEM'
+                            }
+                        );
+                    }
                 });
             };
 


### PR DESCRIPTION
Check whether the stored procedure exists before calling it.
Prevent the following uncaugt exception -  FATAL admin db : error TypeError (context="sql port") TypeError: Cannot read property 'call' of undefined