### PR TITLE
fix: pause/resume mssql request stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dot-prop": "4.2.0",
     "fs-plus": "3.0.2",
     "json-stringify-deterministic": "1.0.1",
-    "mssql": "^5.1.0",
+    "mssql": "5.1.0",
     "readable-stream": "2.3.3",
     "uuid": "3.3.2",
     "xml2js": "0.4.19"

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "dot-prop": "4.2.0",
     "fs-plus": "3.0.2",
     "json-stringify-deterministic": "1.0.1",
+    "mssql": "^5.1.0",
     "readable-stream": "2.3.3",
-    "mssql": "4.3.1",
     "uuid": "3.3.2",
     "xml2js": "0.4.19"
   },


### PR DESCRIPTION
Remove the neccessity to use async queue!
pause/resume mssql request stream on demand.

Note: pausing/resuming was introduced in mssql version [5.0.0](https://github.com/tediousjs/node-mssql/releases?after=v6.0.0-alpha.1) so an upgrade is needed.