### PR TITLE
Fix/rowversion response

### DIFF
--- a/index.js
+++ b/index.js
@@ -772,7 +772,13 @@ module.exports = function({utPort, registerErrors}) {
             let isAsync = false;
             const pipeline = [];
             Object.entries(columns).forEach(([key, column]) => {
-                if (column.type.declaration === 'varbinary') {
+                if (column.type.declaration.toUpperCase() === ROW_VERSION_INNER_TYPE) {
+                    pipeline.push(record => {
+                        if (record[key]) { // value is not null
+                            record[key] = record[key].toString('hex');
+                        }
+                    });
+                } else if (column.type.declaration === 'varbinary') {
                     if (this.cbc && isEncrypted(column)) {
                         pipeline.push(record => {
                             if (record[key]) { // value is not null

--- a/index.js
+++ b/index.js
@@ -900,6 +900,8 @@ module.exports = function({utPort, registerErrors}) {
                     } else if (/^(date.*|smalldate.*)$/.test(column.type.declaration)) {
                         // set a javascript date for 'date', 'datetime', 'datetime2' 'smalldatetime'
                         return new Date(value);
+                    } else if (typeof value === 'string' && column.type.declaration.toUpperCase() === ROW_VERSION_INNER_TYPE) {
+                        return /^[0-9A-Fa-f]+$/.test(value) ? Buffer.from(value, 'hex') : Buffer.from(value, 'utf-8');
                     } else if (column.type.declaration === 'time') {
                         return new Date('1970-01-01T' + value + 'Z');
                     } else if (column.type.declaration === 'xml') {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "pegjs": "0.10.0",
     "tap": "^12.6.0",
-    "ut-tools": "^6.25.6"
+    "ut-tools": "^6.27.4"
   },
   "peerDependencies": {
     "ut-bus": "^7.1.1"


### PR DESCRIPTION
turn binary fields into hex in response. This is used when returning rowversion for example.