### PR TITLE
Fixes on passing buffer and fetching db schema table types definitions

### DIFF
--- a/params.js
+++ b/params.js
@@ -55,7 +55,7 @@ function getValue(cbc, hmac, ngram, index, param, column, value, def, updated) {
             return xmlBuilder.buildObject(obj);
         } else if (value.type === 'Buffer') {
             return Buffer.from(value.data);
-        } else if (typeof value === 'object' && !(value instanceof Date)) {
+        } else if (typeof value === 'object' && !(value instanceof Date) && !Buffer.isBuffer(value)) {
             return JSON.stringify(value);
         }
     }

--- a/sql.js
+++ b/sql.js
@@ -74,7 +74,7 @@ module.exports = {
         JOIN
             sys.columns c ON types.type_table_object_id = c.object_id
         JOIN
-            sys.systypes AS st ON st.xtype = c.system_type_id
+            sys.systypes AS st ON st.xusertype = c.user_type_id
         WHERE
             types.is_user_defined = 1 AND st.name <> 'sysname'
         ORDER BY


### PR DESCRIPTION
This fixes minor bug, where Buffer objects are stringified, instead of being passed directly as well as major bug preventing the sql port to establish connection, if database schema has user defined data types.