### PR TITLE
fix: bug in fetching db table types when user defined data types exists

### DIFF
--- a/sql.js
+++ b/sql.js
@@ -71,7 +71,7 @@ module.exports = {
         JOIN
             sys.columns c ON types.type_table_object_id = c.object_id
         JOIN
-            sys.systypes AS st ON st.xtype = c.system_type_id
+            sys.systypes AS st ON st.xusertype = c.user_type_id
         WHERE
             types.is_user_defined = 1 AND st.name <> 'sysname'
         ORDER BY


### PR DESCRIPTION
Apply the fix for fetching table types containing user defined data types to hotfix branch for version 7.4