### PR TITLE
fix: xmlParserOptions to be passed to xml2js parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ module.exports = function(createParams) {
                 cbcStable: {},
                 compatibilityLevel: 120,
                 cbcDate: {},
+                xmlParserOptions: {},
                 connection: {
                     driver: 'mssql',
                     TrustServerCertificate: 'yes',
@@ -308,6 +309,7 @@ module.exports = function(createParams) {
                 charkey: 'text',
                 mergeAttrs: true,
                 explicitArray: false,
+                ...this.config.xmlParserOptions,
                 ...this.cbc && {
                     tagNameProcessors: [rename],
                     attrNameProcessors: [rename],


### PR DESCRIPTION
e.g. if you want the parser to return `null` instead of `''` for empty tags, then pass the following config:

```yaml
db:
  xmlParserOptions:
    emptyTag: null
```